### PR TITLE
feat: Implement global configuration system (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ source venv/bin/activate
 pip install -e .
 ```
 
-### 2. Basic Usage
+### 2. Configuration & Setup
+
+Before running the pipeline, you need to initialize your global configuration:
+
+```bash
+jobcd init
+```
+
+This will create an appropriate configuration directory (e.g., `~/.config/jobcd` on Linux/macOS) and initialize your `.env` and `profiles.json` files.
+
+### 3. Basic Usage
 
 Automate your outreach in three simple steps:
 
@@ -60,8 +70,10 @@ jobcd dispatch
 
 ## ⚙️ Configuration
 
+`job-cd` stores its data and configuration in a global directory determined by your operating system (e.g., `~/Library/Application Support/jobcd` on macOS).
+
 ### 1. Environment Variables
-Create a `.env` file in the root directory:
+The `jobcd init` command creates a `.env` file in your global config directory. You can manually edit it to update your keys:
 
 ```env
 GOOGLE_API_KEY=your_gemini_key
@@ -73,7 +85,7 @@ SMTP_PASSWORD=your_app_password
 ```
 
 ### 2. Personalization (Profiles)
-`job-cd` uses your profile to tailor outreach. Create `.cache/profiles.json`:
+`job-cd` uses your profile to tailor outreach. A default profile is created in `.cache/profiles.json` within your global config directory:
 
 ```json
 {

--- a/job_cd/core/config.py
+++ b/job_cd/core/config.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+import typer
+
+from job_cd.core.io import read_json, write_json
+
+class ConfigManager:
+    """
+    Manages global configuration paths, directory structures, and state for job-cd.
+    """
+
+    def __init__(self, app_name: str = "jobcd", base_path: Path = None):
+        # 1. Check for system environment variable override (for CI/CD or power users)
+        env_dir = os.environ.get(f"{app_name.upper()}_CONFIG_DIR")
+
+        # 2. Resolve the base directory
+        if base_path:
+            self.app_dir = Path(base_path)
+        elif env_dir:
+            self.app_dir = Path(env_dir)
+        else:
+            self.app_dir = Path(typer.get_app_dir(app_name))
+
+        # 3. Define subdirectories
+        self.cache_dir = self.app_dir / ".cache"
+        self.prompts_dir = self.app_dir / "prompts"
+
+    def ensure_dirs(self):
+        """Explicitly called via `jobcd init` or lazily before writing data."""
+        self.app_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.prompts_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Path Properties ---
+    @property
+    def db_path(self) -> Path:
+        return self.app_dir / "job_history.db"
+
+    @property
+    def env_path(self) -> Path:
+        return self.app_dir / ".env"
+
+    @property
+    def profiles_path(self) -> Path:
+        return self.cache_dir / "profiles.json"
+
+    @property
+    def contacts_cache_path(self) -> Path:
+        return self.cache_dir / "contacts.json"
+
+    def get_cache_path(self, filename: str) -> Path:
+        """Returns a Path object for a specific file inside the cache directory."""
+        return self.cache_dir / filename
+
+# Export as a singleton to be imported across the application
+config_manager = ConfigManager()

--- a/job_cd/core/io.py
+++ b/job_cd/core/io.py
@@ -1,0 +1,31 @@
+# job_cd/core/io.py
+import os
+import json
+import uuid
+from pathlib import Path
+
+
+def read_json(path: Path, default: dict = None) -> dict:
+    """Reads JSON from disk. Returns default (or {}) on missing/corrupt files."""
+    if not path.exists():
+        return default or {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return default or {}
+
+
+def write_json(path: Path, data: dict):
+    """Writes JSON to disk using atomic replacement to prevent corruption."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+
+    try:
+        temp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(temp_path, path)
+    finally:
+        if temp_path.exists():
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass

--- a/job_cd/main.py
+++ b/job_cd/main.py
@@ -1,8 +1,12 @@
+import textwrap
+
 import typer
 from typing import Optional
 from dotenv import load_dotenv
 
+from job_cd.core.config import config_manager
 from job_cd.core.dispatcher import Dispatcher
+from job_cd.core.interfaces import CacheStrategy
 from job_cd.core.models import DeploymentProfile, IntakePayload
 from job_cd.core.pipeline import ExtractorStep, JobPipelineEngine, FinderStep, EmailComposerStep
 from job_cd.enums import DeploymentStatus
@@ -14,10 +18,78 @@ from job_cd.providers.finder import ApolloFinder
 from job_cd.providers.intake import SimpleWebIntake
 from job_cd.providers.sender import SmtpEmailSender
 
+# Load global configuration first, then local override if exists
+load_dotenv(config_manager.env_path)
 load_dotenv()
 
 app = typer.Typer(help="job-cd: Continuous Deployment for Job Applications")
-db = SQLiteDatabaseAdapter()
+
+def get_db():
+    """Factory function to provide the db strategy."""
+    return SQLiteDatabaseAdapter()
+
+def get_cache(filename: str = "contacts.json") -> CacheStrategy:
+    """Factory function to provide the cache strategy."""
+    return LocalCache(filename=filename)
+
+@app.command()
+def init():
+    """
+    Bootstrap the job-cd environment. 
+    Creates global config directories and initializes a default .env file.
+    """
+    typer.secho("\n🛠️  Initializing job-cd Global Configuration", fg=typer.colors.BLUE, bold=True)
+    
+    config_manager.ensure_dirs()
+    
+    typer.echo(f"Config Directory: {typer.style(str(config_manager.app_dir), fg=typer.colors.CYAN)}")
+
+    if config_manager.env_path.exists():
+        if not typer.confirm("⚠️  .env file already exists. Do you want to overwrite it?"):
+            typer.secho("Aborted initialization.", fg=typer.colors.YELLOW)
+            return
+
+    # Prompt for key settings
+    google_api_key = typer.prompt("Enter your Google Gemini API Key", hide_input=True)
+    apollo_api_key = typer.prompt("Enter your Apollo.io API Key", hide_input=True)
+    
+    smtp_server = typer.prompt("SMTP Server", default="smtp.gmail.com")
+    smtp_port = typer.prompt("SMTP Port", default="587")
+    smtp_user = typer.prompt("SMTP Username (Email)")
+    smtp_pass = typer.prompt("SMTP Password (App Password)", hide_input=True)
+
+    env_content = textwrap.dedent(f"""\
+            # job-cd Global Configuration
+            GOOGLE_API_KEY={google_api_key}
+            APOLLO_API_KEY={apollo_api_key}
+
+            # SMTP Configuration
+            SMTP_SERVER={smtp_server}
+            SMTP_PORT={smtp_port}
+            SMTP_USERNAME={smtp_user}
+            SMTP_PASSWORD={smtp_pass}
+        """)
+    
+    config_manager.env_path.write_text(env_content, encoding="utf-8")
+    typer.secho(f"\n✅ Configuration saved to {config_manager.env_path}", fg=typer.colors.GREEN)
+    
+    # Create a dummy default profile if it doesn't exist
+    if not config_manager.profiles_path.exists():
+        default_profile = {
+            "first_name": "Ted",
+            "last_name": "Lasso",
+            "email": "ted.lasso@afcrichmond.com",
+            "current_role": "Head Coach",
+            "years_of_experience": 20,
+            "target_contact_titles": ["Owner", "Director of Football"],
+            "resume_url": "https://example.com/resume.pdf",
+            "resume_text": "# TED LASSO\nHead Coach | AFC Richmond\n\n- Expert in team building and 'Believe' philosophy."
+        }
+        profile_cache = get_cache("profiles.json")
+        profile_cache.set("default", default_profile)
+        typer.secho(f"✅ Default profile created at {config_manager.profiles_path}", fg=typer.colors.GREEN)
+
+    typer.secho("\n🚀  job-cd is ready! Use 'jobcd build <url>' to get started.", fg=typer.colors.BLUE, bold=True)
 
 
 @app.command()
@@ -27,9 +99,13 @@ def build(
     company: Optional[str] = typer.Option(None, "--company", help="Manual override for company name"),
     domain: Optional[str] = typer.Option(None, "--domain", help="Manual override for company domain")
 ):
+    """
+    Execute the job pipeline for a job posting.
+    """
     typer.secho(f"\n🚀  Starting Build Pipeline", fg=typer.colors.BLUE, bold=True)
     typer.secho(f"🔗  Target: {url}", fg=typer.colors.WHITE, dim=True)
 
+    db = get_db()
     existing_deployments = db.filter(job_link=url)
     if existing_deployments:
         if not typer.confirm("⚠️  A record for this job URL already exists. Do you want to continue adding a new record for this job post?"):
@@ -37,13 +113,13 @@ def build(
             return
     
     payload = IntakePayload(url=url, manual_title=title, manual_company=company, manual_domain=domain)
-    cache = LocalCache()
-    profile_cache = LocalCache(filename="profiles.json")
+    cache = get_cache(filename="contacts.json")
+    profile_cache = get_cache(filename="profiles.json")
     profile_data = profile_cache.get("default")
     if not profile_data:
         typer.secho("\n⚠️  No Profile Found!", fg=typer.colors.YELLOW, bold=True)
         typer.echo("To use job-cd, you must first define your application persona.")
-        typer.echo(f"Please create a profile at: {typer.style('.cache/profiles.json', fg=typer.colors.CYAN)}")
+        typer.echo(f"Please create a profile at: {typer.style(config_manager.profiles_path, fg=typer.colors.CYAN)}")
         typer.echo("\nExample structure:")
         typer.secho('{\n  "default": {\n    "first_name": "Ted",\n    "last_name": "Lasso",\n    "email": "ted.lasso@afcrichmond.com",\n    ...\n  }\n}', fg=typer.colors.WHITE, dim=True)
         return
@@ -103,6 +179,7 @@ def dispatch(
     else:
         typer.secho("🔄  Checking outbox for due deployments...", fg=typer.colors.BLUE)
 
+    db = get_db()
     sender = SmtpEmailSender()
     dispatcher = Dispatcher(db=db, sender=sender)
 
@@ -125,6 +202,7 @@ def retry():
     Recovery Step: Resend any emails that failed previously.
     """
     typer.secho("🚑  Attempting to rescue failed deployments...", fg=typer.colors.YELLOW, bold=True)
+    db = get_db()
     dispatcher = Dispatcher(db=db, sender=SmtpEmailSender())
 
     try:
@@ -147,6 +225,7 @@ def history(
     """
     Audit Log: View recent job application history.
     """
+    db = get_db()
     deployments = db.filter(limit=limit)
     if not deployments:
         typer.secho("History is empty.", fg=typer.colors.WHITE, dim=True)
@@ -195,8 +274,9 @@ def history(
 @app.command()
 def preview(limit: int = 1):
     """
-    🔍 QA Step: Read the next drafted email waiting in the queue.
+    Read the next drafted email waiting in the queue.
     """
+    db = get_db()
     deployments = db.filter(status=DeploymentStatus.DRAFTED, limit=limit)
     if not deployments:
         typer.secho("📭  No drafted emails in the queue to preview.", fg=typer.colors.YELLOW)

--- a/job_cd/providers/cache.py
+++ b/job_cd/providers/cache.py
@@ -1,9 +1,8 @@
-import os
-import json
-from abc import ABC
 from typing import Optional
 
+from job_cd.core.config import config_manager
 from job_cd.core.interfaces import CacheStrategy
+from job_cd.core.io import read_json, write_json
 
 
 class LocalCache(CacheStrategy):
@@ -11,22 +10,13 @@ class LocalCache(CacheStrategy):
     Stores key-value pairs in a local JSON file.
     """
     def __init__(self, filename: str = 'contacts.json') -> None:
-        self.filepath = os.path.join(os.getcwd(), ".cache", filename)
-
-        os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
-        if not os.path.exists(self.filepath):
-            with open(self.filepath, 'w') as f:
-                json.dump({}, f)
+        self.filepath = config_manager.get_cache_path(filename)
 
     def get(self, key: str) -> Optional[dict]:
-        with open(self.filepath, 'r') as f:
-            data = json.load(f)
+        data = read_json(self.filepath)
         return data.get(key)
 
     def set(self, key: str, value: dict) -> None:
-        with open(self.filepath, 'r') as f:
-            data = json.load(f)
-
+        data = read_json(self.filepath)
         data[key] = value
-        with open(self.filepath, 'w') as f:
-            json.dump(data, f, indent=4)
+        write_json(self.filepath, data)

--- a/job_cd/providers/database.py
+++ b/job_cd/providers/database.py
@@ -1,8 +1,10 @@
 import json
 import sqlite3
 import logging
-from typing import Optional, List
+from pathlib import Path
+from typing import Optional, List, Union
 
+from job_cd.core.config import config_manager
 from job_cd.core.interfaces import DatabaseStrategy
 from job_cd.core.models import JobDeployment
 from job_cd.enums import DeploymentStatus
@@ -14,12 +16,15 @@ class SQLiteDatabaseAdapter(DatabaseStrategy):
     Stores the complex Pydantic model as a JSON string for easy retrieval.
     """
 
-    def __init__(self, db_path: str = "job_history.db"):
-        self.db_path = db_path
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or config_manager.db_path
         self._initialize_db()
 
     def _initialize_db(self):
         """Creates the database and table if they don't exist."""
+        # Ensure the directory exists
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
         with sqlite3.connect(self.db_path) as conn:
             conn.execute('''
                          CREATE TABLE IF NOT EXISTS deployments (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,11 @@ dependencies = [
     "google-genai",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-mock",
+]
+
 [project.scripts]
 jobcd = "job_cd.main:app"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+import json
+from typer.testing import CliRunner
+from job_cd.main import app
+from job_cd.core.config import ConfigManager
+
+runner = CliRunner()
+
+
+def test_init_command(tmp_path, monkeypatch):
+    """Test the 'init' command bootstrapping process."""
+    base_dir = tmp_path / "jobcd_test"
+    test_cm = ConfigManager(base_path=base_dir)
+
+    print(f"\n[Test] Using temporary directory: {base_dir}")
+
+    # Mock the global config_manager in main.py
+    monkeypatch.setattr("job_cd.main.config_manager", test_cm)
+    # Mock the global config_manager in providers to avoid real path creation
+    monkeypatch.setattr("job_cd.providers.database.config_manager", test_cm)
+    monkeypatch.setattr("job_cd.providers.cache.config_manager", test_cm)
+
+    # Mock typer.prompt to provide automated inputs
+    user_inputs = (
+        "mock-google-key\n"
+        "mock-apollo-key\n"
+        "smtp.gmail.com\n"
+        "587\n"
+        "user@example.com\n"
+        "mock-password\n"
+    )
+
+    # Inject the inputs directly into the runner
+    result = runner.invoke(app, ["init"], input=user_inputs)
+
+    # Print the exact terminal output captured by the runner
+    print("\n--- CLI Terminal Output ---")
+    print(result.stdout)
+    print("-------------------------------\n")
+
+    assert result.exit_code == 0
+    assert "Initializing job-cd Global Configuration" in result.stdout
+    assert "Configuration saved" in result.stdout
+
+    # Verify files were created
+    assert (base_dir / ".env").exists()
+    assert (base_dir / ".cache" / "profiles.json").exists()
+
+    # Verify .env content
+    with open(base_dir / ".env", "r") as f:
+        content = f.read()
+        print("--- Generated .env File ---")
+        print(content)
+        print("------------------------------\n")
+        assert "GOOGLE_API_KEY=mock-google-key" in content
+        assert "APOLLO_API_KEY=mock-apollo-key" in content
+        assert "SMTP_USERNAME=user@example.com" in content
+
+    # Verify profiles.json content
+    with open(base_dir / ".cache" / "profiles.json", "r") as f:
+        profile = json.load(f)
+        print("--- Generated profiles.json File ---")
+        print(json.dumps(profile, indent=2))
+        print("---------------------------------------\n")
+        assert "default" in profile
+        assert profile["default"]["email"] == "ted.lasso@afcrichmond.com"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,60 @@
+import pytest
+from pathlib import Path
+from job_cd.core.config import ConfigManager
+
+
+def test_config_manager_paths(tmp_path):
+    """Test that ConfigManager generates correct paths based on the base directory."""
+    base_dir = tmp_path / "jobcd_test"
+    cm = ConfigManager(base_path=base_dir)
+
+    print(f"\n--- test_config_manager_paths ---")
+    print(f"Base Directory: {base_dir}")
+    print(f"  -> DB Path:       {cm.db_path}")
+    print(f"  -> Env Path:      {cm.env_path}")
+    print(f"  -> Profiles Path: {cm.profiles_path}")
+    print(f"  -> Cache Path:    {cm.get_cache_path('test.json')}")
+    print("------------------------------------\n")
+
+    assert cm.db_path == base_dir / "job_history.db"
+    assert cm.env_path == base_dir / ".env"
+    assert cm.profiles_path == base_dir / ".cache" / "profiles.json"
+    assert cm.contacts_cache_path == base_dir / ".cache" / "contacts.json"
+    assert cm.get_cache_path("test.json") == base_dir / ".cache" / "test.json"
+
+
+def test_config_manager_ensure_dirs(tmp_path):
+    """Test that ensure_dirs creates the necessary directory structure."""
+    base_dir = tmp_path / "jobcd_test"
+    cm = ConfigManager(base_path=base_dir)
+
+    print(f"\n--- test_config_manager_ensure_dirs ---")
+    print(f"Base Directory: {base_dir}")
+    print(f"  -> Exists BEFORE ensure_dirs(): {base_dir.exists()}")
+    assert not base_dir.exists()
+
+    cm.ensure_dirs()
+
+    print(f"  -> Exists AFTER ensure_dirs():  {base_dir.exists()}")
+    print(f"  -> Cache folder created?        {(base_dir / '.cache').exists()}")
+    print(f"  -> Prompts folder created?      {(base_dir / 'prompts').exists()}")
+    print("------------------------------------------\n")
+
+    assert base_dir.exists()
+    assert (base_dir / ".cache").exists()
+    assert (base_dir / "prompts").exists()
+
+
+def test_config_manager_default_path(monkeypatch):
+    """Test that ConfigManager uses typer.get_app_dir by default."""
+    mock_app_dir = "/mock/app/dir"
+    monkeypatch.setattr("typer.get_app_dir", lambda name: mock_app_dir)
+
+    cm = ConfigManager()
+
+    print(f"\n--- test_config_manager_default_path ---")
+    print(f"Mocked Typer App Dir: {mock_app_dir}")
+    print(f"ConfigManager Result: {cm.app_dir}")
+    print("-------------------------------------------\n")
+
+    assert cm.app_dir == Path(mock_app_dir)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,67 @@
+import pytest
+from pathlib import Path
+from job_cd.providers.database import SQLiteDatabaseAdapter
+from job_cd.providers.cache import LocalCache
+from job_cd.core.config import ConfigManager
+
+
+def test_database_adapter_uses_config_path(tmp_path, monkeypatch):
+    """Test that SQLiteDatabaseAdapter uses the path from ConfigManager by default."""
+
+    # 1. ARRANGE: Set up an isolated temporary directory for this specific test
+    base_dir = tmp_path / "jobcd_test"
+    test_cm = ConfigManager(base_path=base_dir)
+
+    print(f"\n--- test_database_adapter ---")
+    print(f"Mocked Base Dir: {base_dir}")
+
+    # Intercept the global config_manager inside the database module
+    # and replace it with our test_cm so it doesn't touch the real OS.
+    monkeypatch.setattr("job_cd.providers.database.config_manager", test_cm)
+
+    # 2. ACT: Initialize the database (This triggers _initialize_db under the hood)
+    db = SQLiteDatabaseAdapter()
+
+    print(f"Database Path Generated: {db.db_path}")
+    print(f"Database Created on Init? {db.db_path.exists()}")
+    print("--------------------------------\n")
+
+    # 3. ASSERT: Verify the path routing and that the SQLite file was actually generated
+    assert db.db_path == base_dir / "job_history.db"
+    assert db.db_path.exists()
+
+
+def test_cache_uses_config_path(tmp_path, monkeypatch):
+    """Test that LocalCache uses the path from ConfigManager and creates files lazily."""
+
+    # 1. ARRANGE: Set up an isolated temporary directory
+    base_dir = tmp_path / "jobcd_test"
+    test_cm = ConfigManager(base_path=base_dir)
+
+    print(f"\n--- test_cache_uses_config_path ---")
+
+    # Intercept the global config_manager inside the cache module
+    monkeypatch.setattr("job_cd.providers.cache.config_manager", test_cm)
+
+    # 2. ACT (Phase 1): Initialize the cache instance
+    cache = LocalCache(filename="test_cache.json")
+    expected_path = base_dir / ".cache" / "test_cache.json"
+
+    print(f"Expected Cache Path: {expected_path}")
+    print(f"File Exists on Init? {expected_path.exists()} (Expected: False - Lazy Init)")
+
+    # 3. ASSERT (Phase 1): Verify the path is routed correctly, but the disk is UNTOUCHED.
+    assert cache.filepath == expected_path
+    assert not expected_path.exists()
+
+    # 4. ACT (Phase 2): Trigger an atomic save to the disk
+    print("Saving data to cache...")
+    cache.set("test_key", {"status": "success"})
+
+    print(f"File Exists after Set? {expected_path.exists()} (Expected: True)")
+    print(f"Retrieved Data: {cache.get('test_key')}")
+    print("--------------------------------------\n")
+
+    # 5. ASSERT (Phase 2): Verify the new io.py utility safely created the file and saved the data
+    assert expected_path.exists()
+    assert cache.get("test_key") == {"status": "success"}


### PR DESCRIPTION
This PR implements a global configuration system, allowing job-cd to store data in OS-native directories instead of the local project folder. It also introduces the init command to bootstrap the environment variables.

Closes #6 

- Introduced `ConfigManager` to centralize paths for the database, `.env` file, cache, and user profiles into an OS-appropriate global directory.                                                                                                                                                                    
- Added `jobcd init` command to bootstrap the application, prompt for required credentials, and generate a default `.env` and `profiles.json`.                                                                                                                                                                       
- Refactored `SQLiteDatabaseAdapter` and `LocalCache` to utilize the new global paths via `pathlib.Path`.                                                                                                                                                                                                            
- Implemented robust, atomic JSON file I/O operations (`read_json`, `write_json`) to prevent data corruption.                                                                                                                                                                                                        
- Enabled environment variable override (`JOBCD_CONFIG_DIR`) for CI/CD environments.                                                                                                                                                                                                                                
- Added a comprehensive `tests/` directory covering CLI commands, provider paths, and configuration logic.                                                                                                                                                                                                           
- Updated `README.md` to document the new `init` command setup process.