### PR TITLE
feat(config): add view/edit modes with --edit/--open flags

### DIFF
--- a/job_cd/main.py
+++ b/job_cd/main.py
@@ -312,9 +312,32 @@ def preview(limit: int = 1):
 
 
 @app.command()
-def config():
-    """Configure API keys and settings."""
-    typer.secho("Settings coming soon...", fg=typer.colors.YELLOW)    
+def config(
+    edit: bool = typer.Option(
+        False, "--edit", "--open",
+        help="Open the .env file in your default editor"
+    )
+):
+    """View or edit API keys and SMTP settings."""
+    env_path = config_manager.env_path
+
+    if not env_path.exists():
+        typer.secho(
+            "No global configuration found. Please run 'jobcd init' first.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1)
+
+    if edit:
+        typer.secho(
+            "⚠️  WARNING: This file contains sensitive credentials "
+            "(API keys, passwords). Do not share or commit this file.",
+            fg=typer.colors.YELLOW,
+            bold=True,
+        )
+        typer.launch(str(env_path))
+    else:
+        typer.echo(env_path.read_text(encoding="utf-8"))
 
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 from typer.testing import CliRunner
 from job_cd.main import app
 from job_cd.core.config import ConfigManager
@@ -63,3 +64,89 @@ def test_init_command(tmp_path, monkeypatch):
         print("---------------------------------------\n")
         assert "default" in profile
         assert profile["default"]["email"] == "ted.lasso@afcrichmond.com"
+
+
+def test_config_view_mode(tmp_path, monkeypatch):
+    """Test that 'config' displays the .env file content."""
+    base_dir = tmp_path / "jobcd_test"
+    base_dir.mkdir()
+    env_file = base_dir / ".env"
+    env_file.write_text("GOOGLE_API_KEY=test-key\nSMTP_SERVER=smtp.example.com\n")
+
+    test_cm = ConfigManager(base_path=base_dir)
+    monkeypatch.setattr("job_cd.main.config_manager", test_cm)
+
+    result = runner.invoke(app, ["config"])
+
+    print("\n--- test_config_view_mode ---")
+    print(result.stdout)
+    print("-----------------------------\n")
+
+    assert result.exit_code == 0
+    assert "GOOGLE_API_KEY=test-key" in result.stdout
+    assert "SMTP_SERVER=smtp.example.com" in result.stdout
+
+
+def test_config_view_mode_missing_env(tmp_path, monkeypatch):
+    """Test that 'config' shows an error when .env does not exist."""
+    base_dir = tmp_path / "jobcd_test"
+    test_cm = ConfigManager(base_path=base_dir)
+    monkeypatch.setattr("job_cd.main.config_manager", test_cm)
+
+    result = runner.invoke(app, ["config"])
+
+    print("\n--- test_config_view_mode_missing_env ---")
+    print(result.stdout)
+    print("-----------------------------------------\n")
+
+    assert result.exit_code == 1
+    assert "Please run 'jobcd init' first" in result.stdout
+
+
+def test_config_edit_mode(tmp_path, monkeypatch):
+    """Test that 'config --edit' opens the .env file and prints a warning."""
+    base_dir = tmp_path / "jobcd_test"
+    base_dir.mkdir()
+    env_file = base_dir / ".env"
+    env_file.write_text("GOOGLE_API_KEY=test-key\n")
+
+    test_cm = ConfigManager(base_path=base_dir)
+    monkeypatch.setattr("job_cd.main.config_manager", test_cm)
+
+    launch_mock = MagicMock()
+    monkeypatch.setattr("typer.launch", launch_mock)
+
+    result = runner.invoke(app, ["config", "--edit"])
+
+    print("\n--- test_config_edit_mode ---")
+    print(result.stdout)
+    print("-----------------------------\n")
+
+    assert result.exit_code == 0
+    assert "WARNING" in result.stdout
+    assert "sensitive credentials" in result.stdout
+    launch_mock.assert_called_once_with(str(env_file))
+
+
+def test_config_edit_alias(tmp_path, monkeypatch):
+    """Test that 'config --open' behaves identically to '--edit'."""
+    base_dir = tmp_path / "jobcd_test"
+    base_dir.mkdir()
+    env_file = base_dir / ".env"
+    env_file.write_text("GOOGLE_API_KEY=test-key\n")
+
+    test_cm = ConfigManager(base_path=base_dir)
+    monkeypatch.setattr("job_cd.main.config_manager", test_cm)
+
+    launch_mock = MagicMock()
+    monkeypatch.setattr("typer.launch", launch_mock)
+
+    result = runner.invoke(app, ["config", "--open"])
+
+    print("\n--- test_config_edit_alias ---")
+    print(result.stdout)
+    print("-----------------------------\n")
+
+    assert result.exit_code == 0
+    assert "WARNING" in result.stdout
+    launch_mock.assert_called_once_with(str(env_file))


### PR DESCRIPTION
Enhances jobcd config with view and edit modes, replacing the previous "Settings coming soon..." stub.
Changes
- View mode (jobcd config): displays the .env configuration file contents in the terminal
- Edit mode (jobcd config --edit or jobcd config --open): prints a security warning about sensitive credentials, then opens the .env file in the default OS editor via typer.launch()
- Missing .env: shows a helpful error instructing the user to run jobcd init first, exits cleanly with code 1
- Tests: 4 new tests covering view mode, missing env, edit mode, and the --open alias
Verification
pytest -v  # 10 passed in 0.98s
# View mode
jobcd config

# Edit mode
jobcd config --edit
jobcd config --open    # identical alias